### PR TITLE
attempt 2: add system properties to build args

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -100,6 +100,8 @@
           </execution>
         </executions>
       </plugin>
+
+<!--  System properties for native image testing -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -112,6 +114,8 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
+
+
       <plugin>
         <?m2e ignore?>
         <groupId>org.codehaus.mojo</groupId>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -101,6 +101,18 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <spanner.testenv.config.class>com.google.cloud.spanner.GceTestEnvConfig</spanner.testenv.config.class>
+            <spanner.testenv.instance>projects/mpeddada-test/instances/spanner-testing</spanner.testenv.instance>
+            <spanner.gce.config.project_id>mpeddada-test</spanner.gce.config.project_id>
+            <!--            <spanner.testenv.kms_key.name>projects/gcloud-devel/locations/us-east1/keyRings/cmek-test-key-ring/cryptoKeys/cmek-test-key</spanner.testenv.kms_key.name>-->
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
         <?m2e ignore?>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.2.6</version>
+    <version>1.2.7-SNAPSHOT</version>
   </parent>
 
   <developers>
@@ -134,7 +134,6 @@
     <module>proto-google-cloud-spanner-admin-database-v1</module>
     <module>google-cloud-spanner-bom</module>
   </modules>
-
   <build>
     <plugins>
       <!-- TODO: Remove this once the shared configuration updates to use Java 8 -->
@@ -149,6 +148,17 @@
           <compilerArgument>-Xlint:unchecked</compilerArgument>
           <compilerArgument>-Xlint:deprecation</compilerArgument>
           <showDeprecation>true</showDeprecation>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.graalvm.buildtools</groupId>
+        <artifactId>native-maven-plugin</artifactId>
+        <configuration>
+          <buildArgs combine.children="append">
+            <buildArg>--initialize-at-build-time=org.junit.platform.engine.TestTag,com.google.cloud.spanner.connection.it</buildArg>
+            <buildArg>--initialize-at-run-time=io.grpc.netty.shaded.io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod</buildArg>
+          </buildArgs>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,9 @@
           <buildArgs combine.children="append">
             <buildArg>--initialize-at-build-time=org.junit.platform.engine.TestTag,com.google.cloud.spanner.connection.it</buildArg>
             <buildArg>--initialize-at-run-time=io.grpc.netty.shaded.io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod</buildArg>
+            <buildArg>-Dspanner.testenv.config.class=com.google.cloud.spanner.GceTestEnvConfig</buildArg>
+            <buildArg>-Dspanner.testenv.instance=projects/mpeddada-test/instances/spanner-testing</buildArg>
+            <buildArg>-Dspanner.gce.config.project_id=mpeddada-test</buildArg>
           </buildArgs>
         </configuration>
       </plugin>


### PR DESCRIPTION
Adding system properties to build args is still resulting the following error:

```
JUnit Vintage:ITBulkConnectionTest
    ClassSource [className = 'com.google.cloud.spanner.connection.it.ITBulkConnectionTest', filePosition = null]
    => java.lang.NullPointerException: Property spanner.testenv.config.class needs to be set
       com.google.cloud.spanner.IntegrationTestEnv.initializeConfig(IntegrationTestEnv.java:67)
       com.google.cloud.spanner.IntegrationTestEnv.before(IntegrationTestEnv.java:76)
       org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:50)
       org.junit.rules.RunRules.evaluate(RunRules.java:20)
       org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
       org.junit.runners.ParentRunner.run(ParentRunner.java:413)
       org.junit.runner.JUnitCore.run(JUnitCore.java:137)
       org.junit.runner.JUnitCore.run(JUnitCore.java:115)
       org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:42)
       org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
```
